### PR TITLE
Make WebGPU work with emscripten and C++

### DIFF
--- a/examples/e01_helloclear.nim
+++ b/examples/e01_helloclear.nim
@@ -125,17 +125,13 @@ proc run=
         nextInChain          : nil,
         label                : "Hello Default Queue".toStringView()
         ), #:: defaultQueue
-      deviceLostCallbackInfo : DeviceLostCallbackInfo(
-        nextInChain          : nil,
-        callback             : deviceLostCB,
-        userdata1            : device.addr,
-        userdata2            : nil,
+      deviceLostCallbackInfo : deviceLostCallbackInfo(
+        callback  = deviceLostCB,
+        userdata1 = device.addr,
         ), #:: deviceLostCallback
-      uncapturedErrorCallbackInfo : UncapturedErrorCallbackInfo(
-        nextInChain          : nil,
-        callback             : errorCB,
-        userdata1            : device.addr,
-        userdata2            : nil,
+      uncapturedErrorCallbackInfo : uncapturedErrorCallbackInfo(
+        callback  = errorCB,
+        userdata1 = device.addr,
         ), #:: uncapturedErrorCallback
       ), #:: DeviceDescriptor( ... )
     callbackInfo = RequestDeviceCallbackInfo(
@@ -261,6 +257,3 @@ proc run=
   window.term()
 #__________________
 when isMainModule: run()
-
-
-

--- a/examples/e02_hellotriangle.nim
+++ b/examples/e02_hellotriangle.nim
@@ -168,17 +168,13 @@ proc run=
         nextInChain               : nil,
         label                     : "Hello Default Queue".toStringView()
         ), #:: defaultQueue
-      deviceLostCallbackInfo      : DeviceLostCallbackInfo(
-        nextInChain               : nil,
-        callback                  : deviceLostCB,
-        userdata1                 : device.addr,
-        userdata2                 : nil,
+      deviceLostCallbackInfo      : deviceLostCallbackInfo(
+        callback  = deviceLostCB,
+        userdata1 = device.addr,
         ), #:: deviceLostCallback
-      uncapturedErrorCallbackInfo : UncapturedErrorCallbackInfo(
-        nextInChain               : nil,
-        callback                  : errorCB,
-        userdata1                 : device.addr,
-        userdata2                 : nil,
+      uncapturedErrorCallbackInfo : uncapturedErrorCallbackInfo(
+        callback  = errorCB,
+        userdata1 = device.addr,
         ), #:: uncapturedErrorCallbackInfo
       ), #:: DeviceDescriptor( ... )
     callbackInfo                  = RequestDeviceCallbackInfo(
@@ -351,4 +347,3 @@ proc run=
   window.term()
 #__________________
 when isMainModule: run()
-

--- a/examples/e03_hellobuffer.nim
+++ b/examples/e03_hellobuffer.nim
@@ -77,17 +77,13 @@ proc run=
         nextInChain          : nil,
         label                : "Hello Default Queue".toStringView()
         ),
-      deviceLostCallbackInfo : DeviceLostCallbackInfo(
-        nextInChain          : nil,
-        callback             : deviceLostCB,
-        userdata1            : device.addr,
-        userdata2            : nil,
+      deviceLostCallbackInfo      : deviceLostCallbackInfo(
+        callback  = deviceLostCB,
+        userdata1 = device.addr,
         ),
-      uncapturedErrorCallbackInfo : UncapturedErrorCallbackInfo(
-        nextInChain          : nil,
-        callback             : errorCB,
-        userdata1            : device.addr,
-        userdata2            : nil,
+      uncapturedErrorCallbackInfo : uncapturedErrorCallbackInfo(
+        callback  = errorCB,
+        userdata1 = device.addr,
         ),
       ),
     callbackInfo = RequestDeviceCallbackInfo(

--- a/examples/e04_hellocompute.nim
+++ b/examples/e04_hellocompute.nim
@@ -91,17 +91,13 @@ proc run=
         nextInChain          : nil,
         label                : "Hello Default Queue".toStringView()
         ),
-      deviceLostCallbackInfo : DeviceLostCallbackInfo(
-        nextInChain          : nil,
-        callback             : deviceLostCB,
-        userdata1            : device.addr,
-        userdata2            : nil,
+      deviceLostCallbackInfo      : deviceLostCallbackInfo(
+        callback  = deviceLostCB,
+        userdata1 = device.addr,
         ),
-      uncapturedErrorCallbackInfo : UncapturedErrorCallbackInfo(
-        nextInChain          : nil,
-        callback             : errorCB,
-        userdata1            : device.addr,
-        userdata2            : nil,
+      uncapturedErrorCallbackInfo : uncapturedErrorCallbackInfo(
+        callback  = errorCB,
+        userdata1 = device.addr,
         ),
       ),
     callbackInfo = RequestDeviceCallbackInfo(

--- a/src/wgpu/extras/device.nim
+++ b/src/wgpu/extras/device.nim
@@ -15,46 +15,44 @@ from ./types as extras import nil
 #  These callback constructors and types are used to bypasses C++'s strict function-pointer-type
 #  check when compiling with --backend:cpp.
 #_____________________________
-type
-  DeviceLostCallback * = proc (device :ptr wgpu.Device; reason :wgpu.DeviceLostReason; message :wgpu.StringView; userdata1 :pointer; userdata2 :pointer) {.cdecl.}
-  UncapturedErrorCallback * = proc (device :ptr wgpu.Device; typ :wgpu.ErrorType; message :wgpu.StringView; userdata1 :pointer; userdata2 :pointer) {.cdecl.}
-#___________________
-proc deviceLostCallbackInfoRaw (
+proc deviceLostCallbackInfoImpl (
     callback  :pointer;
-    mode      :wgpu.CallbackMode;
+    mode      :cint;
     userdata1 :pointer;
     userdata2 :pointer;
-  ) :wgpu.DeviceLostCallbackInfo=
-  result.mode      = mode.cint
-  result.userdata1 = userdata1
-  result.userdata2 = userdata2
-  var cb = callback
-  copyMem(addr result.callback, addr cb, sizeof(pointer))
+  ) :wgpu.DeviceLostCallbackInfo {.inline.}=
+  wgpu.DeviceLostCallbackInfo(
+    callback  : cast[wgpu.DeviceLostCallback](callback),
+    mode      : mode,
+    userdata1 : userdata1,
+    userdata2 : userdata2,
+  )
 #___________________
-proc uncapturedErrorCallbackInfoRaw (
+proc uncapturedErrorCallbackInfoImpl (
     callback  :pointer;
     userdata1 :pointer;
     userdata2 :pointer;
-  ) :wgpu.UncapturedErrorCallbackInfo=
-  result.userdata1 = userdata1
-  result.userdata2 = userdata2
-  var cb = callback
-  copyMem(addr result.callback, addr cb, sizeof(pointer))
+  ) :wgpu.UncapturedErrorCallbackInfo {.inline.}=
+  wgpu.UncapturedErrorCallbackInfo(
+    callback  : cast[wgpu.UncapturedErrorCallback](callback),
+    userdata1 : userdata1,
+    userdata2 : userdata2,
+  )
 #___________________
 template deviceLostCallbackInfo *(
-    callback  :DeviceLostCallback;
+    callback  :wgpu.DeviceLostCallback;
     mode      :wgpu.CallbackMode = wgpu.CallbackMode.AllowSpontaneous;
     userdata1 :pointer = nil;
     userdata2 :pointer = nil;
   ) :wgpu.DeviceLostCallbackInfo=
-  deviceLostCallbackInfoRaw(cast[pointer](callback), mode, userdata1, userdata2)
+  deviceLostCallbackInfoImpl(cast[pointer](callback), mode.cint, userdata1, userdata2)
 #___________________
 template uncapturedErrorCallbackInfo *(
-    callback  :UncapturedErrorCallback;
+    callback  :wgpu.UncapturedErrorCallback;
     userdata1 :pointer = nil;
     userdata2 :pointer = nil;
   ) :wgpu.UncapturedErrorCallbackInfo=
-  uncapturedErrorCallbackInfoRaw(cast[pointer](callback), userdata1, userdata2)
+  uncapturedErrorCallbackInfoImpl(cast[pointer](callback), userdata1, userdata2)
 
 
 #_______________________________________

--- a/src/wgpu/extras/device.nim
+++ b/src/wgpu/extras/device.nim
@@ -11,7 +11,6 @@ from ./types as extras import nil
 
 #_______________________________________
 # @section Callback Info Constructors
-# @descr
 #  These callback constructors and types are used to bypasses C++'s strict function-pointer-type
 #  check when compiling with --backend:cpp.
 #_____________________________

--- a/src/wgpu/extras/device.nim
+++ b/src/wgpu/extras/device.nim
@@ -10,6 +10,54 @@ from ./types as extras import nil
 
 
 #_______________________________________
+# @section Callback Info Constructors
+# @descr
+#  These callback constructors and types are used to bypasses C++'s strict function-pointer-type
+#  check when compiling with --backend:cpp.
+#_____________________________
+type
+  DeviceLostCallback * = proc (device :ptr wgpu.Device; reason :wgpu.DeviceLostReason; message :wgpu.StringView; userdata1 :pointer; userdata2 :pointer) {.cdecl.}
+  UncapturedErrorCallback * = proc (device :ptr wgpu.Device; typ :wgpu.ErrorType; message :wgpu.StringView; userdata1 :pointer; userdata2 :pointer) {.cdecl.}
+#___________________
+proc deviceLostCallbackInfoRaw (
+    callback  :pointer;
+    mode      :wgpu.CallbackMode;
+    userdata1 :pointer;
+    userdata2 :pointer;
+  ) :wgpu.DeviceLostCallbackInfo=
+  result.mode      = mode.cint
+  result.userdata1 = userdata1
+  result.userdata2 = userdata2
+  var cb = callback
+  copyMem(addr result.callback, addr cb, sizeof(pointer))
+#___________________
+proc uncapturedErrorCallbackInfoRaw (
+    callback  :pointer;
+    userdata1 :pointer;
+    userdata2 :pointer;
+  ) :wgpu.UncapturedErrorCallbackInfo=
+  result.userdata1 = userdata1
+  result.userdata2 = userdata2
+  var cb = callback
+  copyMem(addr result.callback, addr cb, sizeof(pointer))
+#___________________
+template deviceLostCallbackInfo *(
+    callback  :DeviceLostCallback;
+    mode      :wgpu.CallbackMode = wgpu.CallbackMode.AllowSpontaneous;
+    userdata1 :pointer = nil;
+    userdata2 :pointer = nil;
+  ) :wgpu.DeviceLostCallbackInfo=
+  deviceLostCallbackInfoRaw(cast[pointer](callback), mode, userdata1, userdata2)
+#___________________
+template uncapturedErrorCallbackInfo *(
+    callback  :UncapturedErrorCallback;
+    userdata1 :pointer = nil;
+    userdata2 :pointer = nil;
+  ) :wgpu.UncapturedErrorCallbackInfo=
+  uncapturedErrorCallbackInfoRaw(cast[pointer](callback), userdata1, userdata2)
+
+
+#_______________________________________
 # @section Information
 #_____________________________
 proc features *(device :wgpu.Device) :seq[wgpu.FeatureName]=
@@ -25,4 +73,3 @@ proc limits *(device :wgpu.Device) :wgpu.Limits=
   ## @descr Returns the limits supported by the device as a wgpu.Limits object
   let status = wgpu.get(device, limits= result.addr)
   if status != wgpu.Status.Success: raise newException(extras.DeviceError, "Failed to get the limits of the device: " & $status)
-

--- a/src/wgpu/extras/shaders/wgsl/modules.nim
+++ b/src/wgpu/extras/shaders/wgsl/modules.nim
@@ -22,6 +22,6 @@ proc toDescriptor *(code, label :string) :extras.ShaderModuleDescriptor=
     label       : label.toStringView(),
     ) #:: ShaderModuleDescriptor( ... )
 #___________________
-proc read *(file :string) :wgpu.ShaderModuleDescriptor=  file.readFile.toDescriptor(label = file)
-  ## Reads the given `.wgsl` shader file, and returns a wgpu.ShaderModuleDescriptor for it.
+proc read *(file :string) :extras.ShaderModuleDescriptor=  file.readFile.toDescriptor(label = file)
+  ## Reads the given `.wgsl` shader file, and returns an extras.ShaderModuleDescriptor for it.
 

--- a/src/wgpu/extras/strings.nim
+++ b/src/wgpu/extras/strings.nim
@@ -11,7 +11,7 @@ func toStringView *(val :string) :StringView=  StringView(data: val.cstring, len
 #___________________
 func `$` *(val :StringView) :string=
   ## @descr Converts the given wgpu.StringView into a Nim.string
-  if val.data == nil: return ""
+  if val.data.isNil: return ""
   if val.length == csize_t.high: return $val.data
   if val.length == 0: return ""
   val.data.toOpenArray(0, val.length.int-1).substr()

--- a/src/wgpu/extras/surface.nim
+++ b/src/wgpu/extras/surface.nim
@@ -15,16 +15,34 @@ import ./helpers
 
 
 #_______________________________________
+# @section Emscripten (HTML canvas) context creation
+#_____________________________
+when defined(emscripten):
+  proc getSurfaceEmscripten *(instance :Instance; selector :cstring) :Surface=
+    ## Creates a wgpu Surface bound to the HTML canvas matched by `selector` (e.g. "#vexel-canvas").
+    result = instance.create(vaddr SurfaceDescriptor(
+      label       : StringView(),
+      nextInChain : cast[ptr ChainedStruct](vaddr EmscriptenSurfaceSourceCanvasHTMLSelector(
+        chain     : ChainedStruct(
+          next    : nil,
+          sType   : SType.EmscriptenSurfaceSourceCanvasHTMLSelector,
+          ), #:: chain
+        selector  : StringView(data: selector, length: selector.len.csize_t),
+        )), #:: nextInChain
+      )) #:: instance.createSurface()
+
+
+#_______________________________________
 # @section X11 context creation
 #_____________________________
-when defined(linux) and not defined(wayland):
+elif defined(linux) and not defined(wayland):
   proc getSurfaceX11 *(instance :Instance; win :glfw.Window) :Surface=
     result = instance.create(vaddr SurfaceDescriptor(
       label       : StringView(),
       nextInChain : cast[ptr ChainedStruct](vaddr SurfaceSourceXlibWindow(
         chain     : ChainedStruct(
           next    : nil,
-          sType   : SType_SurfaceSourceXlibWindow,
+          sType   : SType.SurfaceSourceXlibWindow,
           ), #:: chain
         display   : glfw.getX11Display(),
         window    : glfw.getX11Window(win).uint32,
@@ -42,7 +60,7 @@ elif defined(linux) and defined(wayland):
       nextInChain : cast[ptr ChainedStruct](vaddr SurfaceSourceWaylandSurface(
         chain     : ChainedStruct(
           next    : nil,
-          sType   : SType_SurfaceSourceWaylandSurface,
+          sType   : SType.SurfaceSourceWaylandSurface,
           ), #:: chain
         display   : glfw.getWaylandDisplay(),
         surface   : glfw.getWaylandWindow(win),
@@ -63,7 +81,7 @@ elif defined(windows):
       nextInChain : cast[ptr ChainedStruct](vaddr SurfaceSourceWindowsHWND(
         chain     : ChainedStruct(
           next    : nil,
-          sType   : SType_SurfaceSourceWindowsHWND,
+          sType   : SType.SurfaceSourceWindowsHWND,
           ), #:: chain
         hinstance : hinstance,
         hwnd      : hwnd,
@@ -88,7 +106,6 @@ elif defined(macosx):
           next    : nil,
           sType   : SType.SurfaceSourceMetalLayer,
           ), #:: chain
-        # Get metal layer with our nglfw/metal_glue.h extension
         layer     : glfw.getMetalLayer(win),
         )), #:: nextInChain
       )) #:: instance.createSurface()
@@ -97,21 +114,22 @@ elif defined(macosx):
 #_______________________________________
 # @section Native Surface: Any system
 #_____________________________
-proc getSurface *(instance :Instance; win :glfw.Window) :Surface=
-  ## Gets the surface of the window for the given wgpu instance.
-  ## Returns the appropriate native surface based on the system.
-  when defined(linux) and not defined(wayland):
-    result = instance.getSurfaceX11(win)
-  elif defined(linux) and defined(wayland):
-    {.warning: "Wayland Surface support has not been tested yet".}
-    result = instance.getSurfaceWayland(win)
-  elif defined(windows):
-    {.warning: "Windows Surface support has not been tested yet".}
-    result = instance.getSurfaceWin(win)
-  elif defined(macosx):
-    result = instance.getSurfaceMac(win)
-  else:
-    {.error: "Surface creation for this platform is currently not supported".}
+when not defined(emscripten):
+  proc getSurface *(instance :Instance; win :glfw.Window) :Surface=
+    ## Gets the surface of the window for the given wgpu instance.
+    ## Returns the appropriate native surface based on the system.
+    when defined(linux) and not defined(wayland):
+      result = instance.getSurfaceX11(win)
+    elif defined(linux) and defined(wayland):
+      {.warning: "Wayland Surface support has not been tested yet".}
+      result = instance.getSurfaceWayland(win)
+    elif defined(windows):
+      {.warning: "Windows Surface support has not been tested yet".}
+      result = instance.getSurfaceWin(win)
+    elif defined(macosx):
+      result = instance.getSurfaceMac(win)
+    else:
+      {.error: "Surface creation for this platform is currently not supported".}
 
 
 #_______________________________________
@@ -145,4 +163,3 @@ proc capabilities *(
   result.presentModes = caps.presentModes()
   result.alphaModes   = caps.alphaModes()
   caps.freeMembers()
-

--- a/src/wgpu/extras/types.nim
+++ b/src/wgpu/extras/types.nim
@@ -66,18 +66,16 @@ converter toBool *(val: wgpu.Bool32): bool = cast[bool](val)
 #_______________________________________
 # @section Shader Modules
 #_____________________________
-# @descr
-#  Standalone object with the same layout as wgpu.ShaderModuleDescriptor.
-#  Avoids inheriting from the importc'd struct so the C++ backend can compile
-#  it (C++ rejects `: public struct WGPUShaderModuleDescriptor` as a base).
-#_____________________________
 #type ShaderModuleDescriptor * = object of wgpu.ShaderModuleDescriptor
-  ## @descr Alias for wgpu.ShaderModuleDescriptor for calling unref inside its `=destroy` hook
+#  TODO: The original version of this used inheritance to hook into `=destroy` and properly call `GC_unref` on `nextInChain`.
+#  However, when using the C++ backend the Nim-generated code uses `struct WGPUShaderModuleDescriptor` as a base for this type,
+#  causing an error, since inheriting from a struct in C++ is not allowed.
+#_____________________________
 type ShaderModuleDescriptor *{.bycopy.}= object
+  ## @descr Alias for wgpu.ShaderModuleDescriptor for calling unref inside its `=destroy` hook
   nextInChain *:ptr wgpu.ChainedStruct
   label *:wgpu.StringView
 proc `=destroy`*(desc :types.ShaderModuleDescriptor) :void=
-#  GC_unref(cast[ref wgpu.ShaderSourceWGSL](desc.nextInChain))
   if desc.nextInChain != nil:
     GC_unref(cast[ref wgpu.ShaderSourceWGSL](desc.nextInChain))
 #___________________

--- a/src/wgpu/extras/types.nim
+++ b/src/wgpu/extras/types.nim
@@ -66,10 +66,24 @@ converter toBool *(val: wgpu.Bool32): bool = cast[bool](val)
 #_______________________________________
 # @section Shader Modules
 #_____________________________
-type ShaderModuleDescriptor * = object of wgpu.ShaderModuleDescriptor
+# @descr
+#  Standalone object with the same layout as wgpu.ShaderModuleDescriptor.
+#  Avoids inheriting from the importc'd struct so the C++ backend can compile
+#  it (C++ rejects `: public struct WGPUShaderModuleDescriptor` as a base).
+#_____________________________
+#type ShaderModuleDescriptor * = object of wgpu.ShaderModuleDescriptor
   ## @descr Alias for wgpu.ShaderModuleDescriptor for calling unref inside its `=destroy` hook
+type ShaderModuleDescriptor *{.bycopy.}= object
+  nextInChain *:ptr wgpu.ChainedStruct
+  label *:wgpu.StringView
 proc `=destroy`*(desc :types.ShaderModuleDescriptor) :void=
-  GC_unref(cast[ref wgpu.ShaderSourceWGSL](desc.nextInChain))
+#  GC_unref(cast[ref wgpu.ShaderSourceWGSL](desc.nextInChain))
+  if desc.nextInChain != nil:
+    GC_unref(cast[ref wgpu.ShaderSourceWGSL](desc.nextInChain))
+#___________________
+proc create *(device :wgpu.Device; descriptor :ptr types.ShaderModuleDescriptor) :wgpu.ShaderModule=
+  ## @descr Forwards to wgpu.create after casting our wrapper to the underlying wgpu.ShaderModuleDescriptor
+  wgpu.create(device, cast[ptr wgpu.ShaderModuleDescriptor](descriptor))
 
 #_______________________________________
 # @section Features

--- a/webgpu.nimble
+++ b/webgpu.nimble
@@ -36,8 +36,8 @@ proc copyVulkanLib () =
     cpFile(src, dst)
 
 proc nimcr (args :varargs[string, `$`]) :void=
-  selfExec &"c -r -d:wgpu -d:wgvkWGSL --verbosity:2 --hints:off --path:{srcDir} --outDir:{binDir} " & args.join(" ")
-  # selfExec &"c -r --backend:cpp -d:wgpu -d:wgvkWGSL --verbosity:2 --hints:off --path:{srcDir} --outDir:{binDir} " & args.join(" ")
+  # selfExec &"c -r -d:wgpu -d:wgvkWGSL --verbosity:2 --hints:off --path:{srcDir} --outDir:{binDir} " & args.join(" ")
+  selfExec &"c -r --backend:cpp -d:wgpu -d:wgvkWGSL --verbosity:2 --hints:off --path:{srcDir} --outDir:{binDir} " & args.join(" ")
 #___________________
 template example (name :untyped; descr,file :static string)=
   ## @descr Generates a task to build+run the given example

--- a/webgpu.nimble
+++ b/webgpu.nimble
@@ -37,6 +37,7 @@ proc copyVulkanLib () =
 
 proc nimcr (args :varargs[string, `$`]) :void=
   selfExec &"c -r -d:wgpu -d:wgvkWGSL --verbosity:2 --hints:off --path:{srcDir} --outDir:{binDir} " & args.join(" ")
+  # selfExec &"c -r --backend:cpp -d:wgpu -d:wgvkWGSL --verbosity:2 --hints:off --path:{srcDir} --outDir:{binDir} " & args.join(" ")
 #___________________
 template example (name :untyped; descr,file :static string)=
   ## @descr Generates a task to build+run the given example


### PR DESCRIPTION
## Summary
- Samples compile and run with --backend:cpp
- The library works on web via emscripten

## Added
- Helpers to bypass C++'s pointer incompatibilities
- Emscripten surface as a special case, since it requires a 'selector' that comes from the HTML.

## Changed
- `SType_xxx` enums changed to `SType.xxx`
- Inheriting from ShaderModuleDescriptor does not map well in cpp. Nim tries to convert it into a C++ inheritance. We have to discuss this.
## Notes
- I temporary added `--backend:cpp` to the examples compile args, I'll remove that later and/or create another task to run in cpp mode.